### PR TITLE
[codex] add emergency encounter history helper

### DIFF
--- a/.changeset/smart-swans-rule.md
+++ b/.changeset/smart-swans-rule.md
@@ -1,0 +1,5 @@
+---
+"@digitalmedika/satusehat": minor
+---
+
+Add `createEmergencyEncounterHistory` to build emergency encounter status and class history for IGD and triage flows, including transitions into inpatient care.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SDK ini dirancang untuk:
 Helper builder yang saat ini tersedia:
 
 - `createEncounterBuilder`
+- `createEmergencyEncounterHistory`
 - `createChestXRayStudyBuilder`
 - `createCompleteBloodCountPanelBuilder`
 - `createLaboratoryPanelBuilder`

--- a/docs/helpers/encounter-builder.md
+++ b/docs/helpers/encounter-builder.md
@@ -9,6 +9,8 @@ Helper `createEncounterBuilder` mempermudah penyusunan payload `Encounter` secar
 - IGD
 - kebutuhan custom dengan `Encounter.class` sendiri
 
+Untuk alur IGD/triage yang punya banyak transisi status dan perpindahan class layanan, gunakan `createEmergencyEncounterHistory(...)` supaya `statusHistory` dan `classHistory` terbentuk otomatis dari titik waktu transisi.
+
 Preset yang tersedia:
 
 - `outpatient` -> `AMB`
@@ -149,6 +151,96 @@ const encounter = createEncounterBuilder({
   .build();
 ```
 
+## Contoh Alur IGD/Triage
+
+```ts
+import {
+  createEmergencyEncounterHistory,
+  createEncounterBuilder,
+} from "@digitalmedika/satusehat";
+
+const emergencyFlow = createEmergencyEncounterHistory({
+  statusStages: [
+    {
+      status: "arrived",
+      start: "2024-04-03T01:00:00+00:00",
+    },
+    {
+      status: "triaged",
+      start: "2024-04-03T01:05:00+00:00",
+    },
+    {
+      status: "in-progress",
+      start: "2024-04-03T01:15:00+00:00",
+    },
+  ],
+  classStages: [
+    {
+      start: "2024-04-03T01:00:00+00:00",
+      preset: "emergency",
+    },
+    {
+      start: "2024-04-03T03:00:00+00:00",
+      preset: "inpatient",
+    },
+  ],
+  periodEnd: "2024-04-05T05:00:00+00:00",
+});
+
+const encounter = createEncounterBuilder({
+  ...emergencyFlow,
+  identifier: {
+    system: "http://sys-ids.kemkes.go.id/encounter/10000004",
+    use: "official",
+    value: "IGD-20240001",
+  },
+  subject: {
+    reference: "Patient/100000030009",
+  },
+  reasonCode: {
+    coding: [
+      {
+        system: "http://terminology.hl7.org/CodeSystem/encounter-reason",
+        code: "29857009",
+        display: "Chest pain",
+      },
+    ],
+  },
+  diagnosis: {
+    condition: {
+      reference: "Condition/4bbbe654-14f5-4ab3-a36e-a1e307f67bb8",
+    },
+    use: {
+      coding: [
+        {
+          system: "https://www.hl7.org/fhir/Codesystem-diagnosis-role",
+          code: "AD",
+          display: "Admission diagnosis",
+        },
+      ],
+    },
+    rank: 1,
+  },
+  location: {
+    location: {
+      reference: "Location/igd-observation-bed-02",
+      display: "Bed Observasi IGD 02",
+    },
+    status: "active",
+  },
+  serviceProvider: {
+    reference: "Organization/10000004",
+  },
+}).build();
+```
+
+Aturan helper ini:
+
+- status pertama harus `arrived`
+- setiap `start` harus urut naik
+- `periodEnd` otomatis menjadi akhir status dan class terakhir
+- kalau `classStages` tidak diberikan, helper akan membuat 1 class `emergency` untuk seluruh encounter
+
 ## Method Utama
 
 - `setPreset(preset)`
@@ -180,4 +272,5 @@ const encounter = createEncounterBuilder({
 
 - Constructor otomatis mengisi `statusHistory` dan `classHistory` default dari `status`, `period`, dan preset atau `encounterClass` yang dipilih.
 - `setPreset(...)` hanya mengubah `class` saat ini. Kalau kamu juga ingin menyesuaikan histori class, tambahkan atau ganti `classHistory` secara eksplisit.
+- `createEmergencyEncounterHistory(...)` mengembalikan `status`, `period`, `encounterClass`, `statusHistory`, dan `classHistory` sehingga bisa langsung di-spread ke `createEncounterBuilder(...)`.
 - `build()` selalu memvalidasi draft akhir dengan `EncounterCreateSchema`.

--- a/src/builders/encounter-builder.ts
+++ b/src/builders/encounter-builder.ts
@@ -90,6 +90,43 @@ export type EncounterHospitalizationHelperInput = Omit<
   dischargeDisposition?: EncounterDischargeDisposition | string;
 };
 
+export interface EmergencyEncounterStatusStageInput {
+  status: EncounterStatus;
+  start: string;
+}
+
+export type EmergencyEncounterClassStageInput =
+  | {
+      start: string;
+      preset: EncounterBuilderPreset;
+      encounterClass?: never;
+    }
+  | {
+      start: string;
+      preset?: never;
+      encounterClass: EncounterClass;
+    };
+
+export interface EmergencyEncounterHistoryInput {
+  statusStages: [
+    EmergencyEncounterStatusStageInput,
+    ...EmergencyEncounterStatusStageInput[],
+  ];
+  periodEnd: string;
+  classStages?: [
+    EmergencyEncounterClassStageInput,
+    ...EmergencyEncounterClassStageInput[],
+  ];
+}
+
+export interface EmergencyEncounterHistoryResult {
+  status: EncounterStatus;
+  period: EncounterCreateInput["period"];
+  encounterClass: EncounterClass;
+  statusHistory: EncounterStatusHistory[];
+  classHistory: EncounterClassHistory[];
+}
+
 function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }
@@ -98,12 +135,88 @@ function cloneEncounterClass(value: EncounterClass): EncounterClass {
   return { ...value };
 }
 
+function parseIsoDateTime(value: string, label: string): number {
+  const timestamp = Date.parse(value);
+
+  if (Number.isNaN(timestamp)) {
+    throw new TypeError(`${label} must be a valid ISO date-time string`);
+  }
+
+  return timestamp;
+}
+
+function assertAscendingTimeline(
+  label: string,
+  starts: { start: string }[],
+  periodEnd: string,
+): void {
+  const endTimestamp = parseIsoDateTime(periodEnd, `${label} periodEnd`);
+
+  let previousTimestamp: number | undefined;
+
+  starts.forEach((entry, index) => {
+    const currentTimestamp = parseIsoDateTime(
+      entry.start,
+      `${label} stage ${index + 1} start`,
+    );
+
+    if (previousTimestamp !== undefined && currentTimestamp <= previousTimestamp) {
+      throw new RangeError(`${label} stages must be sorted in strictly ascending order`);
+    }
+
+    if (currentTimestamp >= endTimestamp) {
+      throw new RangeError(`${label} stage ${index + 1} must start before periodEnd`);
+    }
+
+    previousTimestamp = currentTimestamp;
+  });
+}
+
 function resolveEncounterClass(input: EncounterBuilderInput): EncounterClass {
   if ("encounterClass" in input && input.encounterClass) {
     return cloneEncounterClass(input.encounterClass);
   }
 
   return cloneEncounterClass(ENCOUNTER_CLASS_PRESETS[input.preset]);
+}
+
+function resolveEncounterClassStage(
+  input: EmergencyEncounterClassStageInput,
+): EncounterClass {
+  if ("encounterClass" in input && input.encounterClass) {
+    return cloneEncounterClass(input.encounterClass);
+  }
+
+  return cloneEncounterClass(ENCOUNTER_CLASS_PRESETS[input.preset]);
+}
+
+function createStatusHistoryFromStages(
+  stages: EmergencyEncounterHistoryInput["statusStages"],
+  periodEnd: string,
+): EncounterStatusHistory[] {
+  return stages.map((stage, index) => ({
+    status: stage.status,
+    period: {
+      start: stage.start,
+      end: stages[index + 1]?.start ?? periodEnd,
+    },
+  }));
+}
+
+function createClassHistoryFromStages(
+  stages: [
+    EmergencyEncounterClassStageInput,
+    ...EmergencyEncounterClassStageInput[],
+  ],
+  periodEnd: string,
+): EncounterClassHistory[] {
+  return stages.map((stage, index) => ({
+    class: resolveEncounterClassStage(stage),
+    period: {
+      start: stage.start,
+      end: stages[index + 1]?.start ?? periodEnd,
+    },
+  }));
 }
 
 function normalizeAdmitSource(
@@ -162,6 +275,49 @@ export function createEncounterHospitalization(
   };
 
   return EncounterHospitalizationSchema.parse(hospitalization);
+}
+
+export function createEmergencyEncounterHistory(
+  input: EmergencyEncounterHistoryInput,
+): EmergencyEncounterHistoryResult {
+  const [firstStatusStage] = input.statusStages;
+
+  if (firstStatusStage.status !== "arrived") {
+    throw new RangeError("Emergency encounter flow must start with status 'arrived'");
+  }
+
+  assertAscendingTimeline("Emergency encounter status", input.statusStages, input.periodEnd);
+
+  const classStages = input.classStages ?? [
+    {
+      start: firstStatusStage.start,
+      preset: "emergency",
+    },
+  ];
+
+  assertAscendingTimeline("Emergency encounter class", classStages, input.periodEnd);
+
+  if (classStages[0]?.start !== firstStatusStage.start) {
+    throw new RangeError(
+      "Emergency encounter class timeline must start at the same time as the first status stage",
+    );
+  }
+
+  const statusHistory = createStatusHistoryFromStages(input.statusStages, input.periodEnd);
+  const classHistory = createClassHistoryFromStages(classStages, input.periodEnd);
+  const lastStatusStage = input.statusStages[input.statusStages.length - 1]!;
+  const lastClassStage = classStages[classStages.length - 1]!;
+
+  return {
+    status: lastStatusStage.status,
+    period: {
+      start: firstStatusStage.start,
+      end: input.periodEnd,
+    },
+    encounterClass: resolveEncounterClassStage(lastClassStage),
+    statusHistory,
+    classHistory,
+  };
 }
 
 export function createEncounterLocationServiceClassExtension(

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
 export { OrganizationBuilder, createOrganizationBuilder } from "./builders/organization-builder";
 export {
   EncounterBuilder,
+  createEmergencyEncounterHistory,
   createEncounterHospitalization,
   createEncounterBuilder,
   createEncounterLocationServiceClassExtension,
@@ -157,6 +158,10 @@ export type {
   EncounterBuilderInput,
   EncounterHospitalizationHelperInput,
   EncounterBuilderPreset,
+  EmergencyEncounterClassStageInput,
+  EmergencyEncounterHistoryInput,
+  EmergencyEncounterHistoryResult,
+  EmergencyEncounterStatusStageInput,
 } from "./builders/encounter-builder";
 export type {
   RiskAssessmentBuilderInput,

--- a/tests/encounter-builder.test.ts
+++ b/tests/encounter-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  createEmergencyEncounterHistory,
   createEncounterBuilder,
   createEncounterHospitalization,
   createEncounterLocationServiceClassExtension,
@@ -104,6 +105,137 @@ describe("encounter builder", () => {
       "in-progress",
     ]);
     expect(encounter.location).toHaveLength(2);
+  });
+
+  test("builds IGD statusHistory and classHistory from emergency stage transitions", () => {
+    const fixture = createEncounterFixture("emergency");
+    const emergencyFlow = createEmergencyEncounterHistory({
+      statusStages: [
+        {
+          status: "arrived",
+          start: "2024-04-03T01:00:00+00:00",
+        },
+        {
+          status: "triaged",
+          start: "2024-04-03T01:05:00+00:00",
+        },
+        {
+          status: "in-progress",
+          start: "2024-04-03T01:15:00+00:00",
+        },
+      ],
+      periodEnd: "2024-04-03T03:00:00+00:00",
+    });
+
+    const encounter = createEncounterBuilder({
+      ...emergencyFlow,
+      identifier: fixture.identifier,
+      ...(fixture.type ? { type: fixture.type } : {}),
+      ...(fixture.serviceType ? { serviceType: fixture.serviceType } : {}),
+      ...(fixture.priority ? { priority: fixture.priority } : {}),
+      subject: fixture.subject,
+      ...(fixture.participant ? { participant: fixture.participant } : {}),
+      reasonCode: fixture.reasonCode,
+      diagnosis: fixture.diagnosis,
+      location: fixture.location,
+      serviceProvider: fixture.serviceProvider,
+    }).build();
+
+    expect(encounter.status).toBe("in-progress");
+    expect(encounter.period).toEqual({
+      start: "2024-04-03T01:00:00+00:00",
+      end: "2024-04-03T03:00:00+00:00",
+    });
+    expect(encounter.statusHistory).toEqual(fixture.statusHistory);
+    expect(encounter.class.code).toBe("EMER");
+    expect(encounter.classHistory).toEqual(fixture.classHistory);
+  });
+
+  test("supports class transitions from IGD to rawat inap without manual class history", () => {
+    const fixture = createEncounterFixture("inpatient");
+    const emergencyFlow = createEmergencyEncounterHistory({
+      statusStages: [
+        {
+          status: "arrived",
+          start: "2024-04-02T01:00:00+00:00",
+        },
+        {
+          status: "in-progress",
+          start: "2024-04-02T01:20:00+00:00",
+        },
+        {
+          status: "finished",
+          start: "2024-04-05T03:00:00+00:00",
+        },
+      ],
+      classStages: [
+        {
+          start: "2024-04-02T01:00:00+00:00",
+          preset: "emergency",
+        },
+        {
+          start: "2024-04-02T03:00:00+00:00",
+          preset: "inpatient",
+        },
+      ],
+      periodEnd: "2024-04-05T05:00:00+00:00",
+    });
+
+    const encounter = createEncounterBuilder({
+      ...emergencyFlow,
+      identifier: fixture.identifier,
+      ...(fixture.type ? { type: fixture.type } : {}),
+      ...(fixture.serviceType ? { serviceType: fixture.serviceType } : {}),
+      ...(fixture.priority ? { priority: fixture.priority } : {}),
+      subject: fixture.subject,
+      ...(fixture.participant ? { participant: fixture.participant } : {}),
+      reasonCode: fixture.reasonCode,
+      diagnosis: fixture.diagnosis,
+      ...(fixture.hospitalization ? { hospitalization: fixture.hospitalization } : {}),
+      location: fixture.location,
+      serviceProvider: fixture.serviceProvider,
+      ...(fixture.length ? { length: fixture.length } : {}),
+    }).build();
+
+    expect(encounter.class.code).toBe("IMP");
+    expect(encounter.classHistory).toEqual(fixture.classHistory);
+    expect(encounter.statusHistory).toEqual(fixture.statusHistory);
+  });
+
+  test("rejects inconsistent emergency timelines", () => {
+    expect(() =>
+      createEmergencyEncounterHistory({
+        statusStages: [
+          {
+            status: "triaged",
+            start: "2024-04-03T01:05:00+00:00",
+          },
+        ],
+        periodEnd: "2024-04-03T03:00:00+00:00",
+      }),
+    ).toThrow("Emergency encounter flow must start with status 'arrived'");
+
+    expect(() =>
+      createEmergencyEncounterHistory({
+        statusStages: [
+          {
+            status: "arrived",
+            start: "2024-04-03T01:00:00+00:00",
+          },
+          {
+            status: "triaged",
+            start: "2024-04-03T01:05:00+00:00",
+          },
+        ],
+        classStages: [
+          {
+            start: "2024-04-03T01:05:00+00:00",
+            preset: "emergency",
+          },
+        ],
+        periodEnd: "2024-04-03T03:00:00+00:00",
+      }),
+    ).toThrow("Emergency encounter class timeline must start at the same time");
   });
 
   test("builds rawat inap helpers for hospitalization and service class", () => {


### PR DESCRIPTION
## What changed
- add `createEmergencyEncounterHistory` to build `statusHistory`, `classHistory`, `status`, `period`, and final encounter class for emergency encounter flows
- export the new helper and its supporting types from the package entrypoint
- document the IGD/triage flow usage in the encounter builder docs and README
- add a `minor` changeset for the new helper release

## Why
Emergency and triage encounters often move through multiple status transitions and can shift from IGD into inpatient care. This helper turns those stage timestamps into the final encounter fields automatically so consumers do not need to assemble history arrays by hand.

## Impact
- adds a new public helper for IGD and triage encounter timelines
- keeps existing encounter builder usage intact
- prepares the next release to bump the package as a minor version

## Validation
- `bun test tests/encounter-builder.test.ts`
- `bun run typecheck`
